### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/prepublish.yaml
+++ b/.github/workflows/prepublish.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp311-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-manylinux_2_5_x86_64 *-manylinux1_x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_ARCHS_LINUX: "x86_64"

--- a/.github/workflows/prepublish.yaml
+++ b/.github/workflows/prepublish.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.14.1
+          python -m pip install cibuildwheel==2.16.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp311-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-manylinux_2_5_x86_64 *-manylinux1_x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_ARCHS_LINUX: "x86_64"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,12 +19,12 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==2.14.1
+          python -m pip install cibuildwheel==2.16.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-manylinux_2_5_x86_64 *-manylinux1_x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_ARCHS_LINUX: "x86_64"

--- a/.github/workflows/test_simple.yaml
+++ b/.github/workflows/test_simple.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Linear Assignment Problem Solver
 
-`lapx` basically is Tomas Kazmar's [`gatagat/lap`](https://github.com/gatagat/lap) with support for all Windows/Linux/macOS and Python 3.7/3.8/3.9/3.10/3.11.
+`lapx` basically is Tomas Kazmar's [`gatagat/lap`](https://github.com/gatagat/lap) with support for all Windows/Linux/macOS and Python 3.7/3.8/3.9/3.10/3.11/3.12.
 
 * Based on: [[ed04ab7752]](https://github.com/gatagat/lap/tree/ed04ab7752c7c9688ddcbae534633f34ce04361f)
 * License: BSD-2-Clause, see [`LICENSE`](LICENSE) @[`gatagat`](https://github.com/gatagat)

--- a/lap/__init__.py
+++ b/lap/__init__.py
@@ -13,7 +13,7 @@ lapmod
 
 import sys
 
-__version__ = '0.5.4'
+__version__ = '0.5.5'
 
 try:
     __LAP_SETUP__

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ LONG_DESCRIPTION = open("README.md", encoding="utf-8").read()
 package_name = 'lapx'
 package_path = 'lap'
 _lapjv_src = "_lapjv_src"
-requirments_txt = "requirements.txt"
+requirements_txt = "requirements.txt"
 
 ###################################################################
 
@@ -31,9 +31,9 @@ def get_version_string():
                 delim = '"' if '"' in line else "'"
                 return line.split(delim)[1]
 
-def read_requirments():
-    with open(requirments_txt) as requirments_file:
-        return [line for line in requirments_file.read().splitlines()]
+def read_requirements():
+    with open(requirements_txt) as requirements_file:
+        return [line for line in requirements_file.read().splitlines()]
 
 def include_numpy():
     import numpy as np
@@ -104,7 +104,7 @@ def main_setup():
         package_data=package_data,
         include_package_data=True,
         keywords=['Linear Assignment', 'LAPJV', 'LAPMOD', 'lap'],
-        install_requires=read_requirments(),
+        install_requires=read_requirements(),
         classifiers=['Development Status :: 4 - Beta',
                      'Environment :: Console',
                      'Intended Audience :: Developers',
@@ -117,6 +117,7 @@ def main_setup():
                      'Programming Language :: Python :: 3.9',
                      'Programming Language :: Python :: 3.10',
                      'Programming Language :: Python :: 3.11',
+                     'Programming Language :: Python :: 3.12',
                      'Topic :: Education',
                      'Topic :: Education :: Testing',
                      'Topic :: Scientific/Engineering',


### PR DESCRIPTION
- Add support for Python 3.12
- Fix some typo
- Use the latest `cibuildwheel==2.16.2`
- Bump version to 0.5.5