### PR TITLE
docs: added link to original LAPJV paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
 
 Tomas Kazmar's [`lap`](https://github.com/gatagat/lap) is a [linear assignment problem](https://en.wikipedia.org/wiki/Assignment_problem) solver using Jonker-Volgenant algorithm for dense LAPJV ¹ or sparse LAPMOD ² matrices. Both algorithms are implemented from scratch based solely on the papers ¹˒² and the public domain Pascal implementation provided by A. Volgenant ³. The LAPMOD implementation seems to be faster than the LAPJV implementation for matrices with a side of more than ~5000 and with less than 50% finite coefficients.
 
-<sup>¹ R. Jonker and A. Volgenant, "A Shortest Augmenting Path Algorithm for Dense and Sparse Linear Assignment Problems", Computing 38, 325-340 (1987) </sup><br>
+<sup>¹ [R. Jonker and A. Volgenant, "A Shortest Augmenting Path Algorithm for Dense and Sparse Linear Assignment Problems", Computing 38, 325-340 (1987)](https://gwern.net/doc/statistics/decision/1987-jonker.pdf) </sup><br>
 <sup>² A. Volgenant, "Linear and Semi-Assignment Problems: A Core Oriented Approach", Computer Ops Res. 23, 917-932 (1996) </sup><br>
 <sup>³ http://www.assignmentproblems.com/LAPJV.htm </sup><br>
+
 
 </details>
 


### PR DESCRIPTION
I was searching for the original paper of LAPJV. When I found it, I've decided to update your docs with a link to it.