### PR TITLE
chore: strict upper bound for numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=67.8.0", "Cython>=0.29.32", "numpy>=1.21.6"]
+requires = ["setuptools>=67.8.0", "Cython>=0.29.32", "numpy>=1.21.6,<2"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes #9 

numpy 2.0 will prevent lapx from loading properly. This PR strictly binds the numpy version in order to enforce correct behavior.