### PR TITLE
Release v0.5.12

### DIFF
--- a/.github/workflows/prepublish.yaml
+++ b/.github/workflows/prepublish.yaml
@@ -4,7 +4,7 @@ on: [workflow_dispatch]
 
 jobs:
 
-  build_windows_all:
+  build_windows_intel:
     name: Build windows wheels
     runs-on: windows-latest
     steps:
@@ -14,20 +14,44 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-win32 pp*"
-          CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: windows-all-wheels
+          name: windows-intel-wheels
           path: ./wheelhouse/*.whl
-  
+
+  build_windows_arm:
+    name: Build windows wheels
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==3.1.4
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "pp*"
+          CIBW_ARCHS_WINDOWS: "ARM64"
+      - name: Archive wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm-wheels
+          path: ./wheelhouse/*.whl
+
   build_macos_intel:
     name: Build macos-intel wheels
     runs-on: macos-13
@@ -38,7 +62,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -54,7 +78,7 @@ jobs:
 
   build_macos_arm:
     name: Build macos-arm wheels
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.x
@@ -62,7 +86,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -86,7 +110,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -102,18 +126,21 @@ jobs:
 
   build_linux_arm:
     name: Build linux-arm wheels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
         with:
-          platforms: arm64
+          python-version: '3.x'
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "pp*"
           CIBW_ARCHS_LINUX: "aarch64"
       - name: Archive wheels
         uses: actions/upload-artifact@v4
@@ -132,7 +159,7 @@ jobs:
           python-version: '3.x'
       - name: Install requirements
         run: |
-          pip install "setuptools>=67.2.0"
+          pip install "setuptools>=67.8.0"
           pip install wheel build
       - name: Build .tar.gz
         run: python -m build --sdist

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  build_windows_all:
+  build_windows_intel:
     name: Build windows wheels
     runs-on: windows-latest
     steps:
@@ -17,20 +17,44 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-win32 pp*"
-          CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: pypi-windows-all-wheels
+          name: windows-intel-wheels
           path: ./wheelhouse/*.whl
-  
+
+  build_windows_arm:
+    name: Build windows wheels
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==3.1.4
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "pp*"
+          CIBW_ARCHS_WINDOWS: "ARM64"
+      - name: Archive wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm-wheels
+          path: ./wheelhouse/*.whl
+
   build_macos_intel:
     name: Build macos-intel wheels
     runs-on: macos-13
@@ -41,7 +65,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -52,12 +76,12 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: pypi-macos-intel-wheels
+          name: macos-intel-wheels
           path: ./wheelhouse/*.whl
 
   build_macos_arm:
     name: Build macos-arm wheels
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.x
@@ -65,7 +89,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -76,7 +100,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: pypi-macos-arm-wheels
+          name: macos-arm-wheels
           path: ./wheelhouse/*.whl
 
   build_linux_intel:
@@ -89,7 +113,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.3
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -100,28 +124,31 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: pypi-linux-intel-wheels
+          name: linux-intel-wheels
           path: ./wheelhouse/*.whl
 
   build_linux_arm:
     name: Build linux-arm wheels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v5
         with:
-          platforms: arm64
+          python-version: '3.x'
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==3.1.4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "pp*"
           CIBW_ARCHS_LINUX: "aarch64"
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: pypi-linux-arm-wheels
+          name: linux-arm-wheels
           path: ./wheelhouse/*.whl
 
   build_source:
@@ -135,7 +162,7 @@ jobs:
           python-version: '3.x'
       - name: Install requirements
         run: |
-          pip install "setuptools>=67.2.0"
+          pip install "setuptools>=67.8.0"
           pip install wheel build
       - name: Build .tar.gz
         run: python -m build --sdist
@@ -147,7 +174,7 @@ jobs:
 
   publish_pypi:
     name: Publish to PyPI
-    needs: [build_windows_all, build_macos_intel, build_macos_arm, build_linux_intel, build_linux_arm, build_source]
+    needs: [build_windows_intel, build_macos_arm, build_macos_intel, build_macos_arm, build_linux_intel, build_linux_arm, build_source]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: windows-intel-wheels
+          name: pypi-windows-intel-wheels
           path: ./wheelhouse/*.whl
 
   build_windows_arm:
@@ -52,7 +52,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: windows-arm-wheels
+          name: pypi-windows-arm-wheels
           path: ./wheelhouse/*.whl
 
   build_macos_intel:
@@ -76,7 +76,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: macos-intel-wheels
+          name: pypi-macos-intel-wheels
           path: ./wheelhouse/*.whl
 
   build_macos_arm:
@@ -100,7 +100,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: macos-arm-wheels
+          name: pypi-macos-arm-wheels
           path: ./wheelhouse/*.whl
 
   build_linux_intel:
@@ -124,7 +124,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: linux-intel-wheels
+          name: pypi-linux-intel-wheels
           path: ./wheelhouse/*.whl
 
   build_linux_arm:
@@ -148,7 +148,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v4
         with:
-          name: linux-arm-wheels
+          name: pypi-linux-arm-wheels
           path: ./wheelhouse/*.whl
 
   build_source:
@@ -174,7 +174,7 @@ jobs:
 
   publish_pypi:
     name: Publish to PyPI
-    needs: [build_windows_intel, build_macos_arm, build_macos_intel, build_macos_arm, build_linux_intel, build_linux_arm, build_source]
+    needs: [build_windows_intel, build_windows_arm, build_macos_intel, build_macos_arm, build_linux_intel, build_linux_arm, build_source]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/test_simple.yaml
+++ b/.github/workflows/test_simple.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-13"]
+        os: ["windows-latest", "windows-11-arm", "ubuntu-latest", "ubuntu-24.04-arm", "macos-13", "macos-latest"]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4

--- a/lap/__init__.py
+++ b/lap/__init__.py
@@ -11,7 +11,7 @@ lapmod
     Find optimal (minimum-cost) assignment for a sparse cost matrix.
 """
 
-__version__ = '0.5.11.post1'
+__version__ = '0.5.12'
 
 from ._lapjv import (
     lapjv,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 # Rewrote on 2023/06/24 by rathaROG
-# Updated on 2024/10/08 by rathaROG
+# Updated on 2025/08/31 by rathaROG
 
-import distutils.cmd
-from setuptools import Extension, setup
+from setuptools import Extension, Command, setup
 
 LICENSE = "BSD-2-Clause"
 DESCRIPTION = "Linear Assignment Problem solver (LAPJV/LAPMOD)."
@@ -38,7 +37,7 @@ def compile_cpp(cython_file):
     if rc != 0: raise Exception('Cythonizing %s failed' % cython_file)
     else: return cpp_file
 
-class ExportCythonCommand(distutils.cmd.Command):
+class ExportCythonCommand(Command):
     description = "Export _lapjv binary from source."
     def run(self):
         super().run()
@@ -95,7 +94,6 @@ def main_setup():
                      'Intended Audience :: Developers',
                      'Intended Audience :: Education',
                      'Intended Audience :: Science/Research',
-                     'License :: OSI Approved :: BSD License',
                      'Programming Language :: Python :: 3',
                      'Programming Language :: Python :: 3.7',
                      'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
- Improved setup.py by removing deprecated `distutils`
- Removed legacy `License` classifier from `setup()` metadata
- Added ARM architecture to "Test Simple" workflow
- Updated and improved build and publish workflows